### PR TITLE
Fix race in tests and eliminate symlinks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 before_install: sudo apt-get install libicu-dev -y
 language: ruby
 rvm:
-#  - "1.8.7" File watcher is currently timing out for 1.8.7, but only on Travis.  Will investigate...
-  - "1.9.2"
+  - "1.8.7"
   - "1.9.3"
+  - "2.0.0"
 env: RUBYOPT=rubygems

--- a/lib/github-markdown-preview/html_preview.rb
+++ b/lib/github-markdown-preview/html_preview.rb
@@ -15,11 +15,11 @@ module GithubMarkdownPreview
     attr_accessor :delete_on_exit
 
     def initialize(source_file)
-      @source_file = File.expand_path(source_file)
-
-      unless File.exist?(@source_file)
+      unless File.exist?(source_file)
         raise FileNotFoundError.new("Cannot find source file: #{source_file}")
       end
+
+      @source_file = Pathname.new(source_file).realpath.to_s
 
       @preview_file = @source_file + '.html'
       @update_callbacks = []
@@ -58,7 +58,7 @@ module GithubMarkdownPreview
 
       # teach our listener how to update on change
       @listener.change do
-        update
+          update
       end
     end
 

--- a/test/html_preview_test.rb
+++ b/test/html_preview_test.rb
@@ -24,8 +24,8 @@ class TestHtmlPreview < Minitest::Unit::TestCase
   # Requires you pass a block which returns true when your asynchronous process has finished
   def wait_for_async_operation
     start_time = Time.now
-    wait_limit = 60
-    polling_interval = 0.1
+    wait_limit = 30
+    polling_interval = 0.2
 
     until yield
       if Time.now - start_time > wait_limit
@@ -67,8 +67,8 @@ class TestHtmlPreview < Minitest::Unit::TestCase
   def test_preview_beside_src_file
     write(@source_file_path, '## foo')
     markdown_preview = @ghp.new( @source_file_path )
-    assert_equal File.dirname(@source_file_path),
-                 File.dirname(markdown_preview.preview_file),
+    assert_equal File.dirname(Pathname.new(@source_file_path).realpath),
+                 File.dirname(Pathname.new(markdown_preview.preview_file).realpath),
                  'Preview file should be in same dir as source file'
   end
 
@@ -105,9 +105,10 @@ class TestHtmlPreview < Minitest::Unit::TestCase
     markdown_preview.on_update { updated_by_watch = true }
     markdown_preview.watch
 
-    write(@source_file_path, '## foo bar')
-
-    wait_for_async_operation { updated_by_watch }
+    wait_for_async_operation {
+      write(@source_file_path, '## foo bar')
+      updated_by_watch
+    }
 
     assert_match /.*<h2>foo bar<\/h2>.*/,
                  read(markdown_preview.preview_file)


### PR DESCRIPTION
We were (sometimes) updating the watched file before the Listen thread
was fully set up, meaning Listen couldn't detect the change, and our
test would time out (happened especially often against 1.8).

Eliminate the race, and enable Travis on 1.8 and 2.0.

Also ensure we never use symlinks as they can make Listen cranky.
