### PR TITLE
Improve preview fidelity

### DIFF
--- a/lib/github-markdown-preview/html_preview.rb
+++ b/lib/github-markdown-preview/html_preview.rb
@@ -26,7 +26,7 @@ module GithubMarkdownPreview
 
       @pipeline_context = {
           :asset_root => "https://a248.e.akamai.net/assets.github.com/images/icons/",
-          :gfm => true
+          :gfm => false
       }
 
       @preview_pipeline = HTML::Pipeline.new [
@@ -131,15 +131,14 @@ module GithubMarkdownPreview
         .markdown-body h1 {
           margin-top: 0;
         }
+        .readme-content {
+          width: 750px;
+        }
       </style>
     </head>
     <body class="markdown-body" style="padding:20px;">
-      <div id="slider">
-        <div class="frames">
-          <div class="frame frame-center">
-            #{preview_html}
-          </div>
-        </div>
+      <div class="readme-content">
+        #{preview_html}
       </div>
     </body>
 CONTENT

--- a/test/html_preview_test.rb
+++ b/test/html_preview_test.rb
@@ -43,6 +43,14 @@ class TestHtmlPreview < Minitest::Unit::TestCase
                  'Preview should be correct on initialization'
   end
 
+  def test_headers_without_space
+    write(@source_file_path, '#foo')
+    markdown_preview = @ghp.new( @source_file_path )
+    assert_match /.*<h1>foo<\/h1>.*/,
+                 read(markdown_preview.preview_file),
+                 'Preview should contain header'
+  end
+
   def test_wrapper_markup_included
     write(@source_file_path, '## foo')
     markdown_preview = @ghp.new( @source_file_path )


### PR DESCRIPTION
Github does not apply all GFM rules to markdown files (just comments,
issues, etc.).  Setting gfm=false for html-pipeline gets us matching
this behavior.

Also ensure that our preview has the same width as Github.

Fixes #6.
