### PR TITLE
Make github-linguist optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ target
 .idea
 out
 
+# markdown previews
+*.md.html
+
 # bundler suggested ignores
 *.gem
 *.rbc
@@ -37,6 +40,7 @@ out
 .config
 .yardoc
 Gemfile.lock
+Gemfile.optional.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
-before_install: sudo apt-get install libicu-dev -y
 language: ruby
 rvm:
   - "1.8.7"
   - "1.9.3"
   - "2.0.0"
-env: RUBYOPT=rubygems
+env:
+  - INCLUDE_LINGUIST=true
+  - INCLUDE_LINGUIST=false
+
+before_install:
+  - if [[ "$INCLUDE_LINGUIST" == "true" ]]; then BUNDLE_GEMFILE=Gemfile.optional; sudo apt-get install libicu-dev -y; fi

--- a/Gemfile.optional
+++ b/Gemfile.optional
@@ -1,0 +1,12 @@
+# custom Gemfile for bundling/testing with optional 'github-linguist' dep
+# usage: BUNDLE_GEMFILE=Gemfile.optional bundle <command>
+
+source 'https://rubygems.org'
+
+gemspec
+
+if RUBY_VERSION =~ /1.8/
+    gem 'escape_utils', '~> 0.3'
+end
+
+gem 'github-linguist'

--- a/github-markdown-preview.gemspec
+++ b/github-markdown-preview.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency 'listen', '1.3.1' # pin to latest version of listen which supports Ruby 1.8
-  s.add_dependency 'pygments.rb', '0.5.2' # pin pygments.rb version to work around https://github.com/dmarcotte/github-markdown-preview/issues/11
-  s.add_dependency 'github-linguist', '~> 2.9.4'
   s.add_dependency 'html-pipeline', '~> 1.1'
   s.add_dependency 'sanitize', '2.0.3' # pin to latest version of sanitize which supports Ruby 1.8
   s.add_dependency 'github-markdown', '~> 0.6'

--- a/readme.md
+++ b/readme.md
@@ -10,18 +10,23 @@ This program marries [html-pipeline](https://github.com/jch/html-pipeline) with 
 ```
 gem install github-markdown-preview
 ```
-If the install fails, you may be missing a build dependency for the native extensions used in `github-linguist`.  Check your output for the following error, and install the suggested package:
+
+### Enabling syntax highlighting for code blocks
+To enable syntax highlighting for code blocks, you will need to install [`github-linguist`](https://github.com/github/linguist):
 ```
-*********** icu required (brew install icu4c or apt-get install libicu-dev) ***********
+gem install github-linguist
 ```
-For any other failure, please [file an issue!](https://github.com/dmarcotte/github-markdown-preview/issues)
+
+Note that this install will fail unless your system meets the requirements needed to build it native extensions:
+* You will to either `brew install icu4c` or `apt-get install libicu-dev`
+* On Mac, you will need to have XCode installed (seems like a full install is required, not just the Command Line Tools)
 
 ## Usage
 ### Command line
 ```bash
-# This will write the html preview along side your markdown file (<path/to/github-flavored/file.md.html>)
+# This will write the html preview along side your markdown file (<path/to/markdown/file.md.html>)
 # Open in your favorite browser and enjoy!
-github-markdown-preview <path/to/github-flavored/file.md>
+github-markdown-preview <path/to/markdown/file.md>
 ```
 * The `.html` preview is written beside your `.md` file so that you can validate [relative links](https://github.com/blog/1395-relative-links-in-markup-files) locally
 * The `.html` preview is deleted when the script exits
@@ -59,20 +64,23 @@ preview.delete_on_exit = true
 
 ## Developing
 ```bash
-bundle # grab the dependencies
-rake test # verify you're in good shape
+$ bundle install
+$ rake test
 ```
-If you get a `require` error, you may need to set `RUBYOPT` to tell Ruby to grab dependencies from `rubygems`
+
+Alternatively, to test with optional dependencies
 ```bash
-export RUBYOPT='rubygems' # you'll probably want to persist this wherever you manage your env variables
+$ BUNDLE_GEMFILE=Gemfile.optional bundle install
+$ BUNDLE_GEMFILE=Gemfile.optional rake test
 ```
+
 To run your development copy of the main script without installing it
-```
-bundle exec bin/github-markdown-preview
+```bash
+$ bundle exec bin/github-markdown-preview
 ```
 To install the your development copy to your system
-```
-rake install
+```bash
+$ rake install
 ```
 
 ## Contributing


### PR DESCRIPTION
`github-linguist` can be a pain to install.  Make it optional, only applying syntax highlighting to the preview if it's on hand.
