### PR TITLE
Add "comment mode"

### DIFF
--- a/bin/github-markdown-preview
+++ b/bin/github-markdown-preview
@@ -3,10 +3,15 @@
 require 'github-markdown-preview'
 require 'optparse'
 
+comment_mode = false
 opt_parser = OptionParser.new do |opt|
   opt.banner = "Usage: github-markdown-preview PATH_TO_MD_FILE"
   opt.separator  ""
   opt.separator  "Options"
+
+  opt.on("-c", "--comment-mode", "renders a preview for Github comments/issues") do
+    comment_mode = true
+  end
 
   opt.on("-v", "--version", "print the version") do
     $stdout.puts 'github-markdown-preview version ' + GithubMarkdownPreview::VERSION
@@ -23,7 +28,7 @@ end
 
 begin
   source_file = ARGV.at(0)
-  preview = GithubMarkdownPreview::HtmlPreview.new(source_file)
+  preview = GithubMarkdownPreview::HtmlPreview.new(source_file, { :delete_on_exit => true, :comment_mode => comment_mode })
 rescue GithubMarkdownPreview::FileNotFoundError
   $stderr.puts "#{source_file}: No such file"
   exit 1
@@ -34,9 +39,6 @@ if $stdout.isatty
 else
   $stdout.puts preview.preview_file
 end
-
-# delete preview html on exit
-preview.delete_on_exit = true
 
 # make sure we've said what we have to say before we block watching the file
 $stdout.flush

--- a/github-markdown-preview.gemspec
+++ b/github-markdown-preview.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.authors     = ['Daniel Marcotte']
   s.email       = 'dmarcotte@gmail.com'
   s.homepage    = 'https://github.com/dmarcotte/github-markdown-preview'
-  s.summary     = %q{Use your favorite editor plus the usual edit/refresh cycle to quickly write and polish your Github markdown files.}
-  s.description = %q{Local previews for Github Flavored Markdown files}
+  s.summary     = %q{Use your favorite editor plus the usual edit/refresh cycle to quickly write and polish your Github markdown}
+  s.description = %q{Local previews for Github markdown}
   s.license     = 'MIT'
 
   s.add_dependency 'listen', '1.3.1' # pin to latest version of listen which supports Ruby 1.8

--- a/readme.md
+++ b/readme.md
@@ -1,42 +1,61 @@
 # Local Github Markdown Preview [![Build Status](https://secure.travis-ci.org/dmarcotte/github-markdown-preview.png)](http://travis-ci.org/dmarcotte/github-markdown-preview)
 
-Use your favorite editor plus the usual edit/refresh cycle to quickly write and polish your Github markdown files.
+Use your favorite editor plus the usual edit/refresh cycle to quickly write and polish your markdown for Github.
 
-This program marries [html-pipeline](https://github.com/jch/html-pipeline) with the [Listen file watcher](https://github.com/guard/listen) to provide a high-fidelity preview of Github Flavored Markdown in your local browser which automatically updates on edit.
+This program marries [html-pipeline](https://github.com/jch/html-pipeline) with the [Listen file watcher](https://github.com/guard/listen) to provide a high-fidelity preview (in your local browser, automatically updating on edit) of how Github will render your markdown.
 
 ![sample screenshot](sample.png "Local Github Markdown Preview output")
 
-## Installing
+## Installation
 ```
 gem install github-markdown-preview
 ```
 
-### Enabling syntax highlighting for code blocks
+## Usage
+
+Generate a preview of how Github renders markdown files in a repository:
+
+```bash
+$ github-markdown-preview <path/to/markdown/file.md> # writes <path/to/markdown/file.md>
+```
+
+* The `.html` preview is written beside your `.md` file so that you can validate [relative links](https://github.com/blog/1395-relative-links-in-markup-files) locally
+* The `.html` preview is deleted when the script exits
+
+### Comment mode
+Use the `-c` switch to generate a preview of how Github renders comments/issues, which differs from repository markdown files in a few ways:
+* [newlines](https://help.github.com/articles/github-flavored-markdown#newlines) are rendered as hard breaks
+* `@mentions` are linked to the user's home page
+* TODO: issue numbers are linked to the issue page
+* TODO: [task lists](https://help.github.com/articles/github-flavored-markdown#task-lists) are rendered as checkboxes
+
+```bash
+$ github-markdown-preview -c <path/to/comment/draft.md> # writes <path/to/comment/draft.md.html>
+```
+
+### Enable syntax highlighting for code blocks
 To enable syntax highlighting for code blocks, you will need to install [`github-linguist`](https://github.com/github/linguist):
 ```
 gem install github-linguist
 ```
 
-Note that this install will fail unless your system meets the requirements needed to build it native extensions:
+Note that this install will fail unless your system meets the requirements needed to build its native extensions:
 * You will to either `brew install icu4c` or `apt-get install libicu-dev`
 * On Mac, you will need to have XCode installed (seems like a full install is required, not just the Command Line Tools)
 
-## Usage
-### Command line
-```bash
-# This will write the html preview along side your markdown file (<path/to/markdown/file.md.html>)
-# Open in your favorite browser and enjoy!
-github-markdown-preview <path/to/markdown/file.md>
-```
-* The `.html` preview is written beside your `.md` file so that you can validate [relative links](https://github.com/blog/1395-relative-links-in-markup-files) locally
-* The `.html` preview is deleted when the script exits
-
-### Code
+## Code
+Here's a sample file demonstrating how to call `github-markdown-preview` from your own code:
 ```ruby
 require 'github-markdown-preview'
 
 # create a preview, which writes the source_file.md.html file to disk
 preview = GithubMarkdownPreview::HtmlPreview.new('source_file.md')
+
+# you can also configure your preview with a couple of options
+preview = GithubMarkdownPreview::HtmlPreview.new('source_file.md', {
+    :delete_on_exit => true, # delete the preview when the program exits
+    :comment_mode => true # render using the rules for Github comments/issues
+})
 
 # access the preview information
 preview.source_file # returns 'source_file.md'
@@ -57,12 +76,9 @@ preview.end_watch
 
 # delete the preview file from disk
 preview.delete
-
-# alternatively, tell the preview to delete itself when your program exits
-preview.delete_on_exit = true
 ```
 
-## Developing
+## Development
 ```bash
 $ bundle install
 $ rake test


### PR DESCRIPTION
Add the ability to render a preview of how Github renders comments/issues.

This is invoked with the new `-c` flag.  Known issues: linking issue numbers and rendering task-list checkboxes still need to be implemented.
