### PR TITLE
Render task lists in comment mode

### DIFF
--- a/lib/github-markdown-preview.rb
+++ b/lib/github-markdown-preview.rb
@@ -1,8 +1,8 @@
-
 module GithubMarkdownPreview
   class FileNotFoundError < StandardError; end
 
   require 'github-markdown-preview/version'
   require 'github-markdown-preview/resources'
   require 'github-markdown-preview/html_preview'
+  require 'github-markdown-preview/filter/task_list_filter'
 end

--- a/lib/github-markdown-preview/filter/task_list_filter.rb
+++ b/lib/github-markdown-preview/filter/task_list_filter.rb
@@ -1,0 +1,48 @@
+require 'html/pipeline'
+
+module GithubMarkdownPreview
+  class Pipeline
+    # HTML filter that replaces `[ ] task` and `[x] task` list items with "task list" checkboxes
+    class TaskListFilter < HTML::Pipeline::Filter
+
+      COMPLETE_TASK_PATTERN = /^[\s]*(\[\s\])([\s]+[^\s]*)/
+      INCOMPLETE_TASK_PATTERN = /^[\s]*(\[x\])([\s]+[^\s]*)/
+
+      def task_pattern(complete)
+        task_character = complete ? 'x' : '\s'
+        /^[\s]*(\[#{task_character}\])([\s]+[^\s]*)/
+      end
+
+      def task_markup(complete)
+        "<input class=\"task-list-item-checkbox\" type=\"checkbox\" #{complete ? 'checked' : ''}>"
+      end
+
+      def call
+        doc.search('ul/li').each do |node|
+          first_child = node.children.first
+          next if !first_child.text?
+          content = first_child.to_html
+          html = task_list_item_filter(content)
+          next if html == content
+          node['class'] = 'task-list-item'
+          node.parent()['class'] = 'task-list'
+          first_child.replace(html)
+        end
+        doc
+      end
+
+      # Replace "[ ]" or "[x]" with corresponding checkbox input
+      def task_list_item_filter(text)
+        return text unless text.include?('[ ]') || text.include?('[x]')
+
+        [true, false].each do |complete|
+          text = text.gsub task_pattern(complete) do
+            task_markup(complete) + $2
+          end
+        end
+
+        text
+      end
+    end
+  end
+end

--- a/lib/github-markdown-preview/html_preview.rb
+++ b/lib/github-markdown-preview/html_preview.rb
@@ -54,6 +54,7 @@ module GithubMarkdownPreview
 
       if options[:comment_mode]
         filters << HTML::Pipeline::MentionFilter
+        filters << GithubMarkdownPreview::Pipeline::TaskListFilter
       end
 
       @preview_pipeline = HTML::Pipeline.new filters

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,8 @@ $ github-markdown-preview <path/to/markdown/file.md> # writes <path/to/markdown/
 Use the `-c` switch to generate a preview of how Github renders comments/issues, which differs from repository markdown files in a few ways:
 * [newlines](https://help.github.com/articles/github-flavored-markdown#newlines) are rendered as hard breaks
 * `@mentions` are linked to the user's home page
-* TODO: issue numbers are linked to the issue page
-* TODO: [task lists](https://help.github.com/articles/github-flavored-markdown#task-lists) are rendered as checkboxes
+* [task lists](https://help.github.com/articles/github-flavored-markdown#task-lists) are rendered as checkboxes
+* TODO: issue numbers are linked to the issues page
 
 ```bash
 $ github-markdown-preview -c <path/to/comment/draft.md> # writes <path/to/comment/draft.md.html>

--- a/test/filter/task_list_filter_test.rb
+++ b/test/filter/task_list_filter_test.rb
@@ -1,0 +1,87 @@
+require 'bundler/setup'
+require 'minitest/autorun'
+require 'github-markdown-preview'
+
+class HTML::Pipeline::MentionFilterTest < Minitest::Test
+
+  def filter(html)
+    doc  = Nokogiri::HTML::DocumentFragment.parse(html)
+
+    res  = GithubMarkdownPreview::Pipeline::TaskListFilter.call(doc)
+    assert_same doc, res
+
+    res.to_html
+  end
+
+  def test_filter_text_task
+    html = "<ul><li>[ ] task</li></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul class=\"task-list\"><li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\"> task</li></ul>",
+                 result
+  end
+
+  def test_filter_text_task_done
+    html = "<ul><li>[x] task</li></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul class=\"task-list\"><li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\" checked> task</li></ul>",
+                 result
+  end
+
+  def test_filter_tasks_with_leading_whitespace
+    html = "<ul><li>   [ ] task</li></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul class=\"task-list\"><li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\"> task</li></ul>",
+                 result
+  end
+
+  def test_filter_rich_task
+    html = "<ul><li>[ ] <em>task</em></li></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul class=\"task-list\"><li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\"><em>task</em>\n</li></ul>",
+                 result
+  end
+
+  def test_filter_sub_task
+    html = "<ul><li>[ ] task</li><ul><li>[ ] subtask</li></ul></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul class=\"task-list\">\n<li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\"> task</li>\n<ul class=\"task-list\"><li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\"> subtask</li></ul>\n</ul>",
+                 result
+  end
+
+  def test_filter_combined_tasks
+    html = "<ul><li>[ ] task</li><li>[x] done task</li></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul class=\"task-list\">\n<li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\"> task</li>\n<li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\" checked> done task</li>\n</ul>",
+                 result
+  end
+
+  def test_ignores_taskless_brackets
+    html = "<ul><li>[ ]</li></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul><li>[ ]</li></ul>",
+                 result
+  end
+
+  def test_ignores_no_space_brackets
+    html = "<ul><li>[x]nospace</li></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul><li>[x]nospace</li></ul>",
+                 result
+  end
+
+  def test_ignores_non_start_brackets
+    html = "<ul><li>nope [ ] not a task</li></ul>"
+    result  = filter(html)
+
+    assert_equal "<ul><li>nope [ ] not a task</li></ul>",
+                 result
+  end
+end

--- a/test/html_preview_test.rb
+++ b/test/html_preview_test.rb
@@ -68,6 +68,22 @@ class TestHtmlPreview < Minitest::Test
                  'Preview should render #foo directly'
   end
 
+  def test_default_mode_ignores_task_lists
+    write(@source_file_path, '- [ ] task')
+    markdown_preview = @ghp.new( @source_file_path)
+    assert_match markdown_preview.wrap_preview("<ul>\n<li>[ ] task</li>\n</ul>"),
+                 read(markdown_preview.preview_file),
+                 'Should not contain a task list item in default mode'
+  end
+
+  def test_comment_mode_task_lists
+    write(@source_file_path, '- [ ] task')
+    markdown_preview = @ghp.new( @source_file_path, { :comment_mode => true } )
+    assert_match markdown_preview.wrap_preview("<ul class=\"task-list\">\n<li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\"> task</li>\n</ul>"),
+                 read(markdown_preview.preview_file),
+                 'Should contain a task list item in comment mode'
+  end
+
   def test_newlines_ignored
     write(@source_file_path, "foo\nbar")
     markdown_preview = @ghp.new( @source_file_path )


### PR DESCRIPTION
Enhance the comment preview to simulate the [task lists](https://help.github.com/articles/github-flavored-markdown#task-lists) that Github creates for `- [ ] task` and `- [x] completed task` list items
