### PR TITLE
Render task lists in readmes

### DIFF
--- a/lib/github-markdown-preview/filter/task_list_filter.rb
+++ b/lib/github-markdown-preview/filter/task_list_filter.rb
@@ -3,10 +3,17 @@ require 'html/pipeline'
 module GithubMarkdownPreview
   class Pipeline
     # HTML filter that replaces `[ ] task` and `[x] task` list items with "task list" checkboxes
+    #
+    # Can be configured to render disabled checkboxes for the task by adding
+    # :disabled_tasks => true to the Html pipeline context
     class TaskListFilter < HTML::Pipeline::Filter
 
       COMPLETE_TASK_PATTERN = /^[\s]*(\[\s\])([\s]+[^\s]*)/
       INCOMPLETE_TASK_PATTERN = /^[\s]*(\[x\])([\s]+[^\s]*)/
+
+      def disabled_tasks
+        !!context[:disabled_tasks]
+      end
 
       def task_pattern(complete)
         task_character = complete ? 'x' : '\s'
@@ -14,7 +21,7 @@ module GithubMarkdownPreview
       end
 
       def task_markup(complete)
-        "<input class=\"task-list-item-checkbox\" type=\"checkbox\" #{complete ? 'checked' : ''}>"
+        "<input class=\"task-list-item-checkbox\" type=\"checkbox\" #{complete ? 'checked' : ''} #{disabled_tasks ? 'disabled' : ''}>"
       end
 
       def call

--- a/lib/github-markdown-preview/html_preview.rb
+++ b/lib/github-markdown-preview/html_preview.rb
@@ -65,7 +65,8 @@ module GithubMarkdownPreview
       {
           :asset_root => "https://a248.e.akamai.net/assets.github.com/images/icons/",
           :base_url => "https://github.com/",
-          :gfm => options[:comment_mode]
+          :gfm => options[:comment_mode],
+          :disabled_tasks => !options[:comment_mode]
       }
     end
 
@@ -77,7 +78,8 @@ module GithubMarkdownPreview
           HTML::Pipeline::SanitizationFilter,
           HTML::Pipeline::ImageMaxWidthFilter,
           HTML::Pipeline::HttpsFilter,
-          HTML::Pipeline::EmojiFilter
+          HTML::Pipeline::EmojiFilter,
+          GithubMarkdownPreview::Pipeline::TaskListFilter
       ]
 
       if HtmlPreview::SYNTAX_HIGHLIGHTS
@@ -86,7 +88,6 @@ module GithubMarkdownPreview
 
       if options[:comment_mode]
         filters << HTML::Pipeline::MentionFilter
-        filters << GithubMarkdownPreview::Pipeline::TaskListFilter
       end
 
       filters

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,6 @@ $ github-markdown-preview <path/to/markdown/file.md> # writes <path/to/markdown/
 Use the `-c` switch to generate a preview of how Github renders comments/issues, which differs from repository markdown files in a few ways:
 * [newlines](https://help.github.com/articles/github-flavored-markdown#newlines) are rendered as hard breaks
 * `@mentions` are linked to the user's home page
-* [task lists](https://help.github.com/articles/github-flavored-markdown#task-lists) are rendered as checkboxes
 * [TODO](https://github.com/dmarcotte/github-markdown-preview/issues/17): auto-linked [references](https://help.github.com/articles/github-flavored-markdown#references)
 
 ```bash

--- a/test/filter/task_list_filter_test.rb
+++ b/test/filter/task_list_filter_test.rb
@@ -5,10 +5,10 @@ require 'github-markdown-preview'
 
 class HTML::Pipeline::MentionFilterTest < Minitest::Test
 
-  def filter(html)
+  def filter(html, context = nil)
     doc  = Nokogiri::HTML::DocumentFragment.parse(html)
 
-    res  = GithubMarkdownPreview::Pipeline::TaskListFilter.call(doc)
+    res  = GithubMarkdownPreview::Pipeline::TaskListFilter.call(doc, context)
     assert_same doc, res
 
     res.to_html
@@ -85,4 +85,13 @@ class HTML::Pipeline::MentionFilterTest < Minitest::Test
     assert_equal "<ul><li>nope [ ] not a task</li></ul>",
                  result
   end
+
+  def test_disabled_tasks
+    html = "<ul><li>[ ] task</li></ul>"
+    result  = filter(html, { :disabled_tasks => true })
+
+    assert_equal "<ul class=\"task-list\"><li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\" disabled> task</li></ul>",
+                 result
+  end
+
 end

--- a/test/html_preview_test.rb
+++ b/test/html_preview_test.rb
@@ -69,12 +69,12 @@ class TestHtmlPreview < Minitest::Test
                  'Preview should render #foo directly'
   end
 
-  def test_default_mode_ignores_task_lists
+  def test_default_mode_task_lists
     write(@source_file_path, '- [ ] task')
-    markdown_preview = @ghp.new( @source_file_path)
-    assert_equal markdown_preview.wrap_preview("<ul>\n<li>[ ] task</li>\n</ul>"),
+    markdown_preview = @ghp.new( @source_file_path )
+    assert_equal markdown_preview.wrap_preview("<ul class=\"task-list\">\n<li class=\"task-list-item\">\n<input class=\"task-list-item-checkbox\" type=\"checkbox\" disabled> task</li>\n</ul>"),
                  read(markdown_preview.preview_file),
-                 'Should not contain a task list item in default mode'
+                 'Should contain a (disabled) task list item in default mode'
   end
 
   def test_comment_mode_task_lists


### PR DESCRIPTION
Task lists are now rendered for readmes too, not just comments.  See https://github.com/blog/1825-task-lists-in-all-markdown-documents
