### PR TITLE
Add table of contents if not in comment mode.

### DIFF
--- a/lib/github-markdown-preview/html_preview.rb
+++ b/lib/github-markdown-preview/html_preview.rb
@@ -88,6 +88,8 @@ module GithubMarkdownPreview
 
       if options[:comment_mode]
         filters << HTML::Pipeline::MentionFilter
+      else
+        filters << HTML::Pipeline::TableOfContentsFilter
       end
 
       filters


### PR DESCRIPTION
I couldn't figure out how to make a good test for this that wasn't just a direct copy of the HTML generated by html-pipeline, so I don't have any tests for this yet. Let me know what kind of test you'd find appropriate here.

You may notice that though this works, the pretty little link icon isn't showing on `:hover`. This is because although you've copied the CSS, you have not copied the webfonts that GitHub uses. Unfortunately, these fonts are hardcoded to Rails-generated addresses like "/assets/#{sha_of_file}.tiff", so I think the only way to get those icons would be to copy-paste the tiff / woff files and then add some CSS that links to those files using `@font-face`.

I have not added the CSS files because I'm not sure if it's legal to just copy-paste GitHub's stuff like that.
