### PR TITLE
Fix `unitialized constant GitHub (NameError)`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - "1.9"
   - "2.0"
   - "2.1"
+  - "2.2"
 env:
   - INCLUDE_LINGUIST=true
   - INCLUDE_LINGUIST=false

--- a/github-markdown-preview.gemspec
+++ b/github-markdown-preview.gemspec
@@ -18,6 +18,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'sanitize', '~> 3.0'
   s.add_dependency 'github-markdown', '~> 0.6'
   s.add_dependency 'gemoji', '~> 2.1'
+
+  ##
+  # need to pin json to 1.8.1 for now because of an odd issue with
+  # 1.8.2 that leads to https://github.com/dmarcotte/github-markdown-preview/issues/35
+  # todo: lift this restriction eventually
   s.add_dependency 'json', '1.8.1'
 
   s.add_development_dependency 'minitest', '~> 5.4'

--- a/github-markdown-preview.gemspec
+++ b/github-markdown-preview.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sanitize', '~> 3.0'
   s.add_dependency 'github-markdown', '~> 0.6'
   s.add_dependency 'gemoji', '~> 2.1'
+  s.add_dependency 'json', '1.8.1'
 
   s.add_development_dependency 'minitest', '~> 5.4'
   s.add_development_dependency 'bundler', '~> 1.7'

--- a/lib/github-markdown-preview/version.rb
+++ b/lib/github-markdown-preview/version.rb
@@ -1,3 +1,3 @@
 module GithubMarkdownPreview
-  VERSION = '3.1.3'
+  VERSION = '3.1.4'
 end


### PR DESCRIPTION
For some reason version 1.8.2 of the json gem is leading to the error described in #35.  Pin to 1.8.1 to work around the issue.