### PR TITLE
Prevent nil reference when filtering empty lists (issue #41)

### DIFF
--- a/lib/github-markdown-preview/filter/task_list_filter.rb
+++ b/lib/github-markdown-preview/filter/task_list_filter.rb
@@ -27,7 +27,7 @@ module GithubMarkdownPreview
       def call
         process_task = Proc.new do |node|
           first_child = node.children.first
-          next unless first_child.text?
+          next unless first_child && first_child.text?
           content = first_child.to_html
           html = task_list_item_filter(content)
           next if html == content

--- a/test/filter/task_list_filter_test.rb
+++ b/test/filter/task_list_filter_test.rb
@@ -101,4 +101,11 @@ class HTML::Pipeline::MentionFilterTest < Minitest::Test
                  result
   end
 
+  def test_lists_with_empty_items
+    html = "<ul><li></ul>"
+    result  = filter(html)
+    assert_equal "<ul><li></ul>",
+                 result
+  end
+
 end


### PR DESCRIPTION
See #41.