### PR TITLE
Work around Travis bundler issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ env:
   - INCLUDE_LINGUIST=false
 
 before_install:
+  - gem install bundler
   - if [[ "$INCLUDE_LINGUIST" == "true" ]]; then BUNDLE_GEMFILE=Gemfile.optional; sudo apt-get install libicu-dev -y; fi


### PR DESCRIPTION
The build is running into this issue: https://github.com/travis-ci/travis-ci/issues/3531.

Work around with a before_install `gem install bundler` as suggested there (https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203)